### PR TITLE
Refactor upload video

### DIFF
--- a/app_server/videos.py
+++ b/app_server/videos.py
@@ -58,6 +58,8 @@ def _upload_video():
 	api_upload_video = '/api/upload_video/'
 	response_media_server = post_media_server(os.environ.get('MEDIA_SERVER_URL') + api_upload_video, data)
 	status = {}
+	# Trate de usar el .ok de la response, pero un 500 lo toma como true.
+	# Por suerte estaban los tests para hacermelo notar
 	if response_media_server.status_code == 200:
 		logger.debug('Response from media server upload video is 200')
 		# result, status_code = insert_video_into_db()	# me falta el id del MS

--- a/app_server/videos_db_functions.py
+++ b/app_server/videos_db_functions.py
@@ -1,12 +1,28 @@
 import logging
 import datetime
 from bson import ObjectId
+import pymongo.errors
 
 logger = logging.getLogger('gunicorn.error')
 
-# Me falta el id del MS
-# def insert_video_into_db(video_id, data, collection):
-#
+def insert_video_into_db(video_id, data, collection):
+
+	doc = {'_id': ObjectId(video_id),
+		   'title': data['title'],
+		   'url': data['url'],
+		   'user': data['user'],
+		   'upload_date': datetime.datetime.now(),
+		   'comments': [],
+		   'likes': [],
+		   'dislikes': []
+	}
+	try:
+		collection.insert_one(doc)
+		logger.debug('Successfully inserted new video with id:' + video_id)
+		return 201
+	except pymongo.errors.DuplicateKeyError:
+		logger.error('Pymongo duplicate key error')
+		return 500
 
 def insert_comment_into_video(video_id, user_email, comment, collection):
 

--- a/tests/test_videos_db_functions.py
+++ b/tests/test_videos_db_functions.py
@@ -1,0 +1,57 @@
+from pymongo_inmemory import MongoClient
+from app_server.videos_db_functions import *
+
+DB = 'test_app_server'
+
+def test_new_collection_is_empty():
+	client = MongoClient()
+	coll = client[DB]['videos']
+
+	result = list(coll.find({}))
+	client.close()
+	assert len(result) == 0
+
+### Insert video into db ###
+
+def test_insert_new_video():
+	client = MongoClient()
+	collection = client[DB]['videos']
+
+	data = {
+	 'title': 'test',
+	 'url': 'test.com',
+	 'user': 'test'}
+
+	insert_video_into_db('5edbc9196ab5430010391c79', data, collection)
+
+	result = list(collection.find({}))
+	first_video = result[0]
+	client.close()
+
+	assert len(result) == 1
+	assert first_video['title'] == 'test'
+
+def test_insert_ten_videos():
+	client = MongoClient()
+	collection = client[DB]['videos']
+	for i in range(0, 10):
+		data = {
+		'title': 'test_{0}'.format(i),
+		'url': 'test.com',
+		'user': 'test'}
+
+		# Esto se hace porque sino el id es repetido y tira conflicto.
+		_id = '5edbc9196ab5430010391c7' + str(i)
+		insert_video_into_db(_id, data, collection)
+
+	fifth_video = collection.find_one({'title': 'test_5'})
+	assert fifth_video is not None
+	eleventh_video = collection.find_one({'title': 'test_11'})
+	assert eleventh_video is None
+
+	result = list(collection.find({}))
+	client.close()
+
+	assert len(result) == 10
+	for counter, document in enumerate(result):
+		assert document['title'] == 'test_{0}'.format(counter)


### PR DESCRIPTION
- Método para insertar un nuevo video en la base. Usamos el id que viene del media.
- Endpoint de upload_video usa el método para insertar el video nuevo. Ahora cada vez que se sube un video se carga en la base del media y en la del app.