### PR TITLE
Estadísticas de uso de App Server en DataDog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,18 @@
 FROM python:3
+
+# Install GPG dependencies
+RUN apt-get update \
+ && apt-get install -y gpg apt-transport-https gpg-agent curl ca-certificates
+# Add Datadog repository and signing key
+RUN sh -c "echo 'deb https://apt.datadoghq.com/ stable 7' > /etc/apt/sources.list.d/datadog.list"
+RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 A2923DFF56EDA6E76E55E492D3A80E30382E94DE
+# Install the Datadog agent
+RUN apt-get update && apt-get -y --force-yes install --reinstall datadog-agent
+# Expose DogStatsD and trace-agent ports
+EXPOSE 8125/udp 8126/tcp
+# Copy your Datadog configuration
+COPY datadog-config/ /etc/datadog-agent/
+
 COPY requirements.txt .
 COPY setup.py .
 RUN pip install --upgrade pip
@@ -10,4 +24,5 @@ ENV APP_SERVER_TOKEN_FOR_MEDIA_SERVER='6a3fe107-255e-43f0-9819-386c4f32c41f'
 ENV FIREBASE_SERVER_KEY='AAAAVKWePyU:APA91bEXDvxMY3Xk41S67G1Dnc-1SiybDAoqthftsHWql-IAWS-rSm_jQIJ9wS52-ecU7TNNHrhfCnYE7HEOUfae0qvN7EPIaAeS9riVVmnvtxk4NCDd6Qlt1npAimIlIADqNUOtVjwQ'
 COPY . .
 EXPOSE 8000
-CMD gunicorn --log-level=debug 'app_server:create_app()'
+
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 1. Ejecutamos ```docker run -e AUTH_SERVER_URL=https://chotuve-auth-server-dev.herokuapp.com -e MEDIA_SERVER_URL=https://chotuve-media-server-dev.herokuapp.com -e GUNICORN_CMD_ARGS="--bind=0.0.0.0:8000" -p 8000:8000 --name app-server app-server```
 
+2. Para hacer que las estadísticas se publiquen a Datadog, le agregamos al comando anterior la API key para el Datadog Agent: ```docker run -e AUTH_SERVER_URL=https://chotuve-auth-server-dev.herokuapp.com -e MEDIA_SERVER_URL=https://chotuve-media-server-dev.herokuapp.com -e DD_API_KEY=<DATADOG API KEY> -e GUNICORN_CMD_ARGS="--bind=0.0.0.0:8000" -p 8000:8000 --name app-server app-server```
+
 #### Dockercompose
 
 1. Para poder correr el server dockerizado lo primero que tenemos que hacer es descomentar el

--- a/datadog-config/datadog.yaml
+++ b/datadog-config/datadog.yaml
@@ -1,0 +1,11 @@
+# Documentacion completa de los parametros de configuracion del agente de Datadog:
+# https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
+
+listeners:
+  - name: docker
+config_providers:
+  - name: docker
+    polling: true
+    poll_interval: 1s
+
+python_version: 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+datadog-agent run &
+/opt/datadog-agent/embedded/bin/trace-agent --config=/etc/datadog-agent/datadog.yaml &
+/opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml &
+gunicorn --log-level=debug 'app_server:create_app()'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-datadog-agent run &
-/opt/datadog-agent/embedded/bin/trace-agent --config=/etc/datadog-agent/datadog.yaml &
-/opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml &
+datadog-agent run > /dev/null &
+/opt/datadog-agent/embedded/bin/trace-agent --config=/etc/datadog-agent/datadog.yaml > /dev/null &
+/opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml > /dev/null &
 gunicorn --log-level=debug --statsd-host=localhost:8125 --name=chotuve-app-server 'app_server:create_app()'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@
 datadog-agent run &
 /opt/datadog-agent/embedded/bin/trace-agent --config=/etc/datadog-agent/datadog.yaml &
 /opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml &
-gunicorn --log-level=debug 'app_server:create_app()'
+gunicorn --log-level=debug --statsd-host=localhost:8125 --name=chotuve-app-server 'app_server:create_app()'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ chardet==3.0.4
 click==7.1.1
 codecov==2.1.3
 coverage==5.1
-durable-rules==2.0.28
 dnspython==1.16.0
+durable-rules==2.0.28
 entrypoints==0.3
 firebase-admin==4.3.0
 flake8==3.7.9
@@ -63,6 +63,7 @@ req==1.0.0
 requests==2.23.0
 requests-futures==1.0.0
 rsa==4.0
+setproctitle==1.1.10
 simplejson==3.17.0
 six==1.14.0
 toml==0.10.1


### PR DESCRIPTION
Se exponen métricas del contenedor (CPU, memoria, etc.) y gunicorn (cantidad de hits, status codes, tiempos de respuesta) en un dashboard de [DataDog](https://www.datadoghq.com/)